### PR TITLE
Db subdir and ignore missing

### DIFF
--- a/pg_back
+++ b/pg_back
@@ -222,7 +222,7 @@ do
     # create a directory per database
     if [ ! -d "${PGBK_BACKUP_DIR}/${db}" ]; then
       mkdir "${PGBK_BACKUP_DIR}/${db}"
-      [ $? -ne 0 ] && die "could not create $PGBK_BACKUP_DIR"
+      [ $? -ne 0 ] && die "could not create $PGBK_BACKUP_DIR/${db}"
     fi
 
     ${PGBK_BIN}pg_dump $OPTS $PGBK_OPTS -f $PGBK_BACKUP_DIR/${db}/${db}_`date "+${PGBK_TIMESTAMP}"`.dump $db

--- a/pg_back
+++ b/pg_back
@@ -81,6 +81,11 @@ warn() {
     echo "$(now)  WARNING: $*" 1>&2
 }
 
+pg_query_batch() {
+  [ -z "$1" ] && return 1
+  ${PGBK_BIN}psql $OPTS -At $PGBK_CONNDB -c "$1"
+}
+
 args=`getopt "b:c:P:D:th:p:U:d:qV?" $*`
 if [ $? -ne 0 ]
 then
@@ -157,7 +162,7 @@ fi
 info "target directory is $PGBK_BACKUP_DIR"
 
 # Check if replay pause is available
-PG_HASPAUSE=`${PGBK_BIN}psql $OPTS -At -c "SELECT 1 FROM pg_proc WHERE proname='pg_xlog_replay_pause' AND pg_is_in_recovery();" $PGBK_CONNDB`
+PG_HASPAUSE=$(pg_query_batch "SELECT 1 FROM pg_proc WHERE proname='pg_xlog_replay_pause' AND pg_is_in_recovery();")
 if [ $? != 0 ]; then
     die "could not check for replication control functions"
 fi
@@ -165,7 +170,7 @@ fi
 # Pause replay if dumping from a slave
 if [ "${PG_HASPAUSE}" = "1" ]; then
     info "pausing replication replay"
-    ${PGBK_BIN}psql $OPTS -At -c "SELECT pg_xlog_replay_pause() where pg_is_in_recovery();" $PGBK_CONNDB
+    pg_query_batch "SELECT pg_xlog_replay_pause() where pg_is_in_recovery();"
     if [ $? != 0 ]; then
         die "could not pause replication replay"
     fi
@@ -180,7 +185,7 @@ if [ -z "$PGBK_DBLIST" ]; then
 	DB_QUERY="SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate;"
     fi
 
-    PGBK_DBLIST=`${PGBK_BIN}psql $OPTS -At -c "$DB_QUERY" $PGBK_CONNDB`
+    PGBK_DBLIST=$(pg_query_batch "$DB_QUERY")
     if [ $? != 0 ]; then
 	die "could not list databases"
     fi
@@ -204,7 +209,14 @@ do
 
     # Dump
     info "dumping database \"$db\""
-    ${PGBK_BIN}pg_dump $OPTS $PGBK_OPTS -f $PGBK_BACKUP_DIR/${db}_`date "+${PGBK_TIMESTAMP}"`.dump $db
+
+    # create a directory per database
+    if [ ! -d "${PGBK_BACKUP_DIR}/${db}" ]; then
+      mkdir "${PGBK_BACKUP_DIR}/${db}"
+      [ $? -ne 0 ] && die "could not create $PGBK_BACKUP_DIR"
+    fi
+
+    ${PGBK_BIN}pg_dump $OPTS $PGBK_OPTS -f $PGBK_BACKUP_DIR/${db}/${db}_`date "+${PGBK_TIMESTAMP}"`.dump $db
     rc=$?
     if [ $rc != 0 ]; then
 	out_rc=1
@@ -215,7 +227,7 @@ done
 # Resume replay if dumping from a slave
 if [ "${PG_HASPAUSE}" = "1" ]; then
     info "resuming replication replay"
-    ${PGBK_BIN}psql $OPTS -At -c "SELECT pg_xlog_replay_resume();" $PGBK_CONNDB
+    pg_query_batch "SELECT pg_xlog_replay_resume();"
     if [ $? != 0 ]; then
         die "could not resume replication replay"
     fi

--- a/pg_back
+++ b/pg_back
@@ -169,26 +169,28 @@ fi
 
 # Pause replay if dumping from a slave
 if [ "${PG_HASPAUSE}" = "1" ]; then
-    info "pausing replication replay"
-    pg_query_batch "SELECT pg_xlog_replay_pause() where pg_is_in_recovery();"
-    if [ $? != 0 ]; then
-        die "could not pause replication replay"
-    fi
+   info "pausing replication replay"
+   pg_query_batch "SELECT pg_xlog_replay_pause() where pg_is_in_recovery();"
+   if [ $? != 0 ]; then
+      die "could not pause replication replay"
+   fi
 fi
 
 # Prepare the list of databases to dump
-if [ -z "$PGBK_DBLIST" ]; then
-    info "listing databases"
-    if [ "$PGBK_WITH_TEMPLATES" = "yes" ]; then
-	DB_QUERY="SELECT datname FROM pg_database WHERE datallowconn;"
-    else
-	DB_QUERY="SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate;"
-    fi
+info "listing databases"
+if [ "$PGBK_WITH_TEMPLATES" = "yes" ]; then
+   DB_QUERY="SELECT datname FROM pg_database WHERE datallowconn;"
+else
+   DB_QUERY="SELECT datname FROM pg_database WHERE datallowconn AND NOT datistemplate;"
+fi
 
-    PGBK_DBLIST=$(pg_query_batch "$DB_QUERY")
-    if [ $? != 0 ]; then
-	die "could not list databases"
-    fi
+PGBK_DBLIST_FULL=$(pg_query_batch "$DB_QUERY")
+if [ $? != 0 ]; then
+    die "could not list databases"
+fi
+
+if [ -z "$PGBK_DBLIST" ]; then
+  PGBK_DBLIST=${PGBK_DBLIST_FULL}
 fi
 
 # Dump roles and tablespaces first
@@ -205,6 +207,13 @@ do
     echo $PGBK_EXCLUDE | grep -w $db >/dev/null 2>&1
     if [ $? = 0 ]; then
 	continue
+    fi
+
+    # checking if db exists
+    echo $PGBK_DBLIST_FULL | grep -w $db >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+      info "database '${db}' does not exists, ignoring"
+      continue
     fi
 
     # Dump


### PR DESCRIPTION
Hi Nicolas,

Thanks for your script, it's very useful and easy to maintain and configure

here are two enhancements I suggest : 

**directory for each DB**
All your DB dump are generated in a single backup directory.
It's not easy to find the wanted dump when you have a big retention 

My fix create a directory per database, except the global objects dump "pg_global"

**ignore missing DB explicitly defined**
When the list of databases to dump in PGBK_DBLIST is setted with some missing database name,
an empty dump file is created and an error occurs
In my mind a missing db is not an error and shoud be ignored 

my fix will check each database match with one of the full db list variable before launching the dump command (avoid to request pgsql each time)

Regards
