### PR TITLE
Introduces a temp backup directory versus a final storage location.

### DIFF
--- a/pg_back
+++ b/pg_back
@@ -31,6 +31,7 @@ version="1.3-dev"
 # hardcoded defaults
 PGBK_CONFIG="/etc/postgresql/pg_back.conf"
 PGBK_BACKUP_DIR=/var/backups/postgresql
+PGBK_FINAL_DIR=$PGBK_BACKUP_DIR
 PGBK_TIMESTAMP="%Y-%m-%d_%H-%M-%S"
 PGBK_PURGE=30
 PGBK_OPTS="-Fc"
@@ -156,6 +157,19 @@ fi
 
 info "target directory is $PGBK_BACKUP_DIR"
 
+# Create the final storage directory if missing
+if [ ! -d $PGBK_FINAL_DIR ]; then
+    info "creating directory $PGBK_FINAL_DIR"
+    mkdir -p $PGBK_FINAL_DIR
+    if [ $? != 0 ]; then
+    die "could not create $PGBK_FINAL_DIR"
+    fi
+fi
+
+if [ "${PGBK_FINAL_DIR}" != "${PGBK_BACKUP_DIR}" ]; then
+    info "final storage directory is $PGBK_FINAL_DIR"
+fi
+
 # Check if replay pause is available
 PG_HASPAUSE=`${PGBK_BIN}psql $OPTS -At -c "SELECT 1 FROM pg_proc WHERE proname='pg_xlog_replay_pause' AND pg_is_in_recovery();" $PGBK_CONNDB 2>/dev/null`
 if [ $? != 0 ]; then
@@ -210,6 +224,17 @@ do
 	out_rc=1
 	error "pg_dump of database \"$db\" failed"
     fi
+
+    # Move backups to final storage location
+    if [ $rc = 0 ]; then
+        if [ "${PGBK_FINAL_DIR}" != "${PGBK_BACKUP_DIR}" ]; then
+            info "moving backup files to final storage location"
+            mv $PGBK_BACKUP_DIR/* $PGBK_FINAL_DIR/
+            if [ $? != 0 ]; then
+                die "error moving files to final storage location"
+            fi
+        fi
+    fi
 done
 
 # Resume replay if dumping from a slave
@@ -226,7 +251,7 @@ fi
 # Purge old backups, only if current backup succeeded
 if [ "$out_rc" = 0 ]; then
     info "purging old backups"
-    find $PGBK_BACKUP_DIR -maxdepth 1 -mtime +$PGBK_PURGE -exec rm -rf '{}' ';'
+    find $PGBK_FINAL_DIR -maxdepth 1 -mtime +$PGBK_PURGE -exec rm -rf '{}' ';'
     if [ $? != 0 ]; then
 	die "could not purge all old backups"
     fi

--- a/pg_back.conf
+++ b/pg_back.conf
@@ -6,6 +6,12 @@ PGBK_BIN=
 # Backup directory
 PGBK_BACKUP_DIR=/var/backups/postgresql
 
+# Storage directory
+# if set, backup files will be moved to this directory
+# after the dump is completed and PGBK_BACKUP_DIR
+# will be used as temp storage for the dump only.
+#PGBK_FINAL_DIR=/var/backups/finalstorage
+
 # The timestamp to add at the end of each dump file
 PGBK_TIMESTAMP='%Y-%m-%d_%H-%M-%S'
 


### PR DESCRIPTION
In my environment, I like to create the backup to a local drive for
speed, but once the backup is completed, I want the backup files to
be moved to a backup storage on another server.

With this change, it is now possible to set `PGBK_FINAL_DIR` to a different location than `PGBK_BACKUP_DIR`, when different, the script will move the backup files to the final location upon completion of a backup.

The clean up of backup files occurs in the final directory location.

If no final directory location is specified, the backup directory is used as final location and no moves are attempted.