### PR TITLE
Ensure timestamped dump file removed is the one created

### DIFF
--- a/pg_back
+++ b/pg_back
@@ -253,11 +253,12 @@ do
     fi
 
     # Dump and remember which db were properly dumped for purge
-    info "dumping database \"$db\""
-    if ! ${PGBK_BIN}pg_dump $OPTS $PGBK_OPTS -f $PGBK_BACKUP_DIR/${db}_`date "+${PGBK_TIMESTAMP}"`.dump $db; then
-	out_rc=1
-        rm $PGBK_BACKUP_DIR/${db}_`date "+${PGBK_TIMESTAMP}"`.dump
-	error "pg_dump of database \"$db\" failed"
+    dump="${PGBK_BACKUP_DIR}/${db}_$(date "+${PGBK_TIMESTAMP}").dump"
+    info "dumping database \"$db\" into ${dump}"
+    if ! ${PGBK_BIN}pg_dump $OPTS $PGBK_OPTS -f ${dump} $db; then
+        out_rc=1
+        rm -f ${dump}
+        error "pg_dump of database \"$db\" failed"
     else
         dumped+=( "$db" )
     fi


### PR DESCRIPTION
@orgrim calling `date` on rm can fail to remove the created file since `PGBK_TIMESTAMP` contains seconds. This is a fix.

While at it, we log the dump file created.