### PR TITLE
Comments for PGBK_OPTS on v11 + example for PGBK_EXCLUDE

### DIFF
--- a/pg_back.conf
+++ b/pg_back.conf
@@ -17,14 +17,15 @@ PGBK_PURGE=30
 PGBK_PURGE_MIN_KEEP=0
 
 # Command-line options for pg_dump
+# (Beware: on v11 and above, with "-Fp", you probably want to add "--create")
 PGBK_OPTS="-Fc"
 
 # List of databases to dump (separator is space)
 # If empty, dump all databases which are not templates
 #PGBK_DBLIST="db1 db2"
 
-# Exclude databases
-#PGBK_EXCLUDE=
+# Exclude databases (separator is space)
+#PGBK_EXCLUDE="sampledb1 testdb2"
 
 # Include templates ("yes" or "no")
 PGBK_WITH_TEMPLATES="no"


### PR DESCRIPTION
- Added a comment about the `--create` option that must be set if you do not want to lose information on v11 with `-Fp` (see https://github.com/orgrim/pg_back/issues/17)

- Added comment and an example for PGBK_EXCLUDE in the same spirit as PGBK_DBLIST. When reading  too quickly, it's not obvious that the format is described above.