### PR TITLE
Adding signature feature for dump file

### DIFF
--- a/pg_back
+++ b/pg_back
@@ -47,7 +47,7 @@ usage() {
     echo "  -c config     alternate config file (default: \"$PGBK_CONFIG\")"
     echo "  -P days       purge backups older than this number of days (default: \"$PGBK_PURGE\")"
     echo "  -S algo       signature algorithm (default: \"$SIGNATURE_ALGO\")"
-    echo "                available algo.: none $(find /usr/bin -iname "sha*sum" | xargs -i -n 1 basename '{}' sum | sort | tr '\n' ' ')"
+    echo "                available algo.: none $(find /usr/bin/sha*?sum -type f -printf '%f ' | sed 's/sum//g')"
     echo "  -K number     minimum number of backups to keep when purging or 'all' to keep"
     echo "                everything (default: \"$PGBK_PURGE_MIN_KEEP\")"
     echo "  -D db1,...    list of databases to exclude"

--- a/pg_back
+++ b/pg_back
@@ -7,13 +7,13 @@
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
 # are met:
-# 
+#
 #  1. Redistributions of source code must retain the above copyright
 #     notice, this list of conditions and the following disclaimer.
 #  2. Redistributions in binary form must reproduce the above copyright
 #     notice, this list of conditions and the following disclaimer in the
 #     documentation and/or other materials provided with the distribution.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
 # IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
 # OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -37,6 +37,7 @@ PGBK_PURGE_MIN_KEEP=0
 PGBK_OPTS=("-Fc")
 PGBK_WITH_TEMPLATES="no"
 PGBK_CONNDB="postgres"
+SIGNATURE_ALGO="none"
 
 usage() {
     echo "PostgreSQL simple backup script"
@@ -45,11 +46,13 @@ usage() {
     echo "  -b dir        store dump files there (default: \"$PGBK_BACKUP_DIR\")"
     echo "  -c config     alternate config file (default: \"$PGBK_CONFIG\")"
     echo "  -P days       purge backups older than this number of days (default: \"$PGBK_PURGE\")"
+    echo "  -S algo       signature algorithm (default: \"$SIGNATURE_ALGO\")"
+    echo "                available algo.: none $(find /usr/bin -type f -iname '*sum' | xargs -n 1 basename | xargs)"
     echo "  -K number     minimum number of backups to keep when purging or 'all' to keep"
     echo "                everything (default: \"$PGBK_PURGE_MIN_KEEP\")"
     echo "  -D db1,...    list of databases to exclude"
     echo "  -t            include templates"
-    echo 
+    echo
     echo "  -h hostname   database server host or socket directory (default: \"${PGHOST:-local socket}\")"
     echo "  -p port       database server port (default: \"$PGPORT\")"
     echo "  -U username   database user name (default: \"$PGUSER\")"
@@ -89,7 +92,7 @@ warn() {
 [ -f "$PGBK_CONFIG" ] || PGBK_CONFIG="/etc/postgresql/pg_back.conf"
 
 # Process command line
-args=`getopt "b:c:P:K:D:th:p:U:d:qV?" $*`
+args=`getopt "b:c:P:K:D:th:p:S:U:d:qV?" $*`
 if [ $? -ne 0 ]
 then
     usage 2
@@ -98,11 +101,12 @@ fi
 set -- $args
 for i in $*
 do
-    case "$i" in
+	case "$i" in
 	-b) CLI_BACKUP_DIR=$2; shift 2;;
 	-c) PGBK_CONFIG=$2; shift 2;;
 	-P) CLI_PURGE=$2; shift 2;;
-        -K) CLI_PURGE_MIN_KEEP=$2; shift 2;;
+	-S) CLI_SIGNATURE_ALGO=$2; shift 2;;
+	-K) CLI_PURGE_MIN_KEEP=$2; shift 2;;
 	-D) CLI_EXCLUDE="`echo $2 | tr ',' ' '`"; shift 2;;
 	-t) CLI_WITH_TEMPLATES="yes"; shift;;
 	-h) CLI_HOSTNAME=$2; shift 2;;
@@ -113,7 +117,7 @@ do
 	-V) echo "pg_back version $version"; exit 0;;
 	-\?) usage 1;;
 	--) shift; break;;
-    esac
+	esac
 done
 
 CLI_DBLIST=$*
@@ -138,6 +142,7 @@ fi
 [ -n "$CLI_USERNAME" ] && PGBK_USERNAME=$CLI_USERNAME
 [ -n "$CLI_DBLIST" ] && PGBK_DBLIST=$CLI_DBLIST
 [ -n "$CLI_CONNDB" ] && PGBK_CONNDB=$CLI_CONNDB
+[ -n "$CLI_SIGNATURE_ALGO" ] && SIGNATURE_ALGO=$CLI_SIGNATURE_ALGO
 
 # Prepare common options for pg_dump and pg_dumpall
 [ -n "$PGBK_HOSTNAME" ] && OPTS="$OPTS -h $PGBK_HOSTNAME"
@@ -161,6 +166,12 @@ if [ -n "$PGBK_BIN" ]; then
     fi
 fi
 
+if [ -n "${SIGNATURE_ALGO}" -a "${SIGNATURE_ALGO}" != "none" ]; then
+    which ${SIGNATURE_ALGO}sum &>/dev/null
+    if [ $? -ne 0 ]; then
+        die "Signature program ${SIGNATURE_ALGO}sum is not available to create signature file"
+    fi
+fi
 # Create the backup directory if missing
 if [ ! -d $PGBK_BACKUP_DIR ]; then
     info "creating directory $PGBK_BACKUP_DIR"
@@ -215,8 +226,8 @@ if [ "${PG_HASPAUSE}" = "1" ]; then
                 die "could not resume replication replay"
             fi
 	    echo "The slave database has exclusive locks (vacuum full, truncate or other locking command) running on master"
-            echo "Resuming replication for 10s"
-            sleep 10
+        echo "Resuming replication for 10s"
+        sleep 10
 	fi
     done
 fi
@@ -282,6 +293,10 @@ do
     else
         dumped+=( "$db" )
     fi
+    if [ -n "${SIGNATURE_ALGO}" -a "${SIGNATURE_ALGO}" != "none" ]; then
+        info "creating signature file for $(basename ${dump}) into $(basename ${dump}).${SIGNATURE_ALGO}"
+        ${SIGNATURE_ALGO}sum ${dump} | awk '{ print $1 }' > ${dump}.${SIGNATURE_ALGO}
+    fi
 done
 
 # Resume replay if dumping from a slave
@@ -307,7 +322,7 @@ else
         # with the time of last modification since Epoch. Sort them so
         # that the newest come first and keep
         to_purge=()
-        for t in dump sql; do
+        for t in dump sql ${SIGNATURE_ALGO}; do
             i=1
             while read line; do
                 if (( $i > ${PGBK_PURGE_MIN_KEEP:-0} )); then
@@ -335,4 +350,3 @@ fi
 info "done"
 
 exit $out_rc
-

--- a/pg_back
+++ b/pg_back
@@ -295,7 +295,7 @@ do
     fi
     if [ -n "${SIGNATURE_ALGO}" -a "${SIGNATURE_ALGO}" != "none" ]; then
         info "creating signature file for $(basename ${dump}) into $(basename ${dump}).${SIGNATURE_ALGO}"
-        ${SIGNATURE_ALGO}sum ${dump} | awk '{ print $1 }' > ${dump}.${SIGNATURE_ALGO}
+        ${SIGNATURE_ALGO}sum ${dump} > ${dump}.${SIGNATURE_ALGO}
     fi
 done
 

--- a/pg_back
+++ b/pg_back
@@ -47,7 +47,7 @@ usage() {
     echo "  -c config     alternate config file (default: \"$PGBK_CONFIG\")"
     echo "  -P days       purge backups older than this number of days (default: \"$PGBK_PURGE\")"
     echo "  -S algo       signature algorithm (default: \"$SIGNATURE_ALGO\")"
-    echo "                available algo.: none $(find /usr/bin -iname "*sum" | xargs -n 1 basename | grep sha | sed 's/sum//g' | sort | xargs)"
+    echo "                available algo.: none $(find /usr/bin -iname "sha*sum" | xargs -i -n 1 basename '{}' sum | sort | tr '\n' ' ')"
     echo "  -K number     minimum number of backups to keep when purging or 'all' to keep"
     echo "                everything (default: \"$PGBK_PURGE_MIN_KEEP\")"
     echo "  -D db1,...    list of databases to exclude"

--- a/pg_back
+++ b/pg_back
@@ -47,7 +47,7 @@ usage() {
     echo "  -c config     alternate config file (default: \"$PGBK_CONFIG\")"
     echo "  -P days       purge backups older than this number of days (default: \"$PGBK_PURGE\")"
     echo "  -S algo       signature algorithm (default: \"$SIGNATURE_ALGO\")"
-    echo "                available algo.: none $(find /usr/bin -type f -iname '*sum' | xargs -n 1 basename | xargs)"
+    echo "                available algo.: none $(find /usr/bin -iname "*sum" | xargs -n 1 basename | grep sha | sed 's/sum//g' | sort | xargs)"
     echo "  -K number     minimum number of backups to keep when purging or 'all' to keep"
     echo "                everything (default: \"$PGBK_PURGE_MIN_KEEP\")"
     echo "  -D db1,...    list of databases to exclude"


### PR DESCRIPTION
Tested dump signature feature.

By default, pg_back is working as usual

1° option -S defines algorithm used for signature generation. or SIGNATURE_ALGO var.
2° help, command line option and configuration file option support

3° Example:
 - pg_back -S sha256 ...
will create a additional file called as dump with .sha256 extension containing sha256 sum.

This feature is based on XXXXsum program avalaible on Linux host.

4° If algosum program doesn't exist, pg_back fails at the beginning.

5° signature purges is supported  
touch -d '3 months ago' postgres_2019-09-30_17-46-* 
 
