### PR TITLE
Missing OPTS when querying SHOW ALL

### DIFF
--- a/pg_back
+++ b/pg_back
@@ -310,7 +310,7 @@ fi
 # Dump configuration using SHOW ALL
 dump="$PGBK_BACKUP_DIR/pg_settings_${DUMP_DATE}.out"
 info "saving output of SHOW ALL to ${dump}"
-${PGBK_BIN}psql -X -o "${dump}" -c "SHOW ALL;" $PGBK_CONNDB
+${PGBK_BIN}psql $OPTS -X -o "${dump}" -c "SHOW ALL;" $PGBK_CONNDB
 if [ $? != 0 ]; then
     error "psql -c 'SHOW ALL' failed"
     out_rc=1


### PR DESCRIPTION
See https://github.com/orgrim/pg_back/issues/38

Missing OPTS when querying SHOW ALL was leading to a failure or, worse, a file withe settings from the wrong instance. 