### PR TITLE
force legacy timestamp format on windows

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spf13/pflag"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -117,6 +118,11 @@ func TestValidatePurgeTimeLimitValue(t *testing.T) {
 }
 
 func TestDefaultOptions(t *testing.T) {
+	timeFormat := time.RFC3339
+	if runtime.GOOS == "windows" {
+		timeFormat = "2006-01-02_15-04-05"
+	}
+
 	var want = options{
 		Directory:     "/var/backups/postgresql",
 		Format:        'c',
@@ -128,7 +134,7 @@ func TestDefaultOptions(t *testing.T) {
 		PurgeKeep:     0,
 		SumAlgo:       "none",
 		CfgFile:       "/etc/pg_back/pg_back.conf",
-		TimeFormat:    time.RFC3339,
+		TimeFormat:    timeFormat,
 	}
 
 	got := defaultOptions()
@@ -139,6 +145,10 @@ func TestDefaultOptions(t *testing.T) {
 }
 
 func TestParseCli(t *testing.T) {
+	timeFormat := time.RFC3339
+	if runtime.GOOS == "windows" {
+		timeFormat = "2006-01-02_15-04-05"
+	}
 	var (
 		defaults = defaultOptions()
 		tests    = []struct {
@@ -162,7 +172,7 @@ func TestParseCli(t *testing.T) {
 					PurgeKeep:     0,
 					SumAlgo:       "none",
 					CfgFile:       "/etc/pg_back/pg_back.conf",
-					TimeFormat:    time.RFC3339,
+					TimeFormat:    timeFormat,
 				},
 				false,
 				false,
@@ -182,7 +192,7 @@ func TestParseCli(t *testing.T) {
 					PurgeKeep:     0,
 					SumAlgo:       "none",
 					CfgFile:       "/etc/pg_back/pg_back.conf",
-					TimeFormat:    time.RFC3339,
+					TimeFormat:    timeFormat,
 				},
 				false,
 				false,
@@ -258,6 +268,11 @@ func TestParseCli(t *testing.T) {
 }
 
 func TestLoadConfigurationFile(t *testing.T) {
+	timeFormat := time.RFC3339
+	if runtime.GOOS == "windows" {
+		timeFormat = "2006-01-02_15-04-05"
+	}
+
 	var tests = []struct {
 		params []string
 		fail   bool
@@ -278,7 +293,7 @@ func TestLoadConfigurationFile(t *testing.T) {
 				PurgeKeep:     0,
 				SumAlgo:       "none",
 				CfgFile:       "/etc/pg_back/pg_back.conf",
-				TimeFormat:    time.RFC3339,
+				TimeFormat:    timeFormat,
 			},
 		},
 		{ // ensure comma separated lists work
@@ -296,7 +311,7 @@ func TestLoadConfigurationFile(t *testing.T) {
 				PurgeKeep:     0,
 				SumAlgo:       "none",
 				CfgFile:       "/etc/pg_back/pg_back.conf",
-				TimeFormat:    time.RFC3339,
+				TimeFormat:    timeFormat,
 			},
 		},
 		{
@@ -313,7 +328,7 @@ func TestLoadConfigurationFile(t *testing.T) {
 				PurgeKeep:     0,
 				SumAlgo:       "none",
 				CfgFile:       "/etc/pg_back/pg_back.conf",
-				TimeFormat:    time.RFC3339,
+				TimeFormat:    timeFormat,
 			},
 		},
 		{
@@ -365,7 +380,7 @@ func TestLoadConfigurationFile(t *testing.T) {
 				PurgeKeep:     0,
 				SumAlgo:       "none",
 				CfgFile:       "/etc/pg_back/pg_back.conf",
-				TimeFormat:    time.RFC3339,
+				TimeFormat:    timeFormat,
 				PgDumpOpts:    []string{"-O", "-x"},
 				PerDbOpts: map[string]*dbOpts{"db": &dbOpts{
 					Format:        'c',
@@ -402,7 +417,7 @@ func TestLoadConfigurationFile(t *testing.T) {
 				PurgeKeep:     0,
 				SumAlgo:       "none",
 				CfgFile:       "/etc/pg_back/pg_back.conf",
-				TimeFormat:    time.RFC3339,
+				TimeFormat:    timeFormat,
 				PgDumpOpts:    []string{"-O", "-x"},
 				PerDbOpts: map[string]*dbOpts{"db": &dbOpts{
 					Format:        'c',
@@ -450,6 +465,11 @@ func TestLoadConfigurationFile(t *testing.T) {
 }
 
 func TestMergeCliAndConfigoptions(t *testing.T) {
+	timeFormat := time.RFC3339
+	if runtime.GOOS == "windows" {
+		timeFormat = "2006-01-02_15-04-05"
+	}
+
 	want := options{
 		BinDirectory:  "/bin",
 		Directory:     "test",
@@ -471,7 +491,7 @@ func TestMergeCliAndConfigoptions(t *testing.T) {
 		PreHook:       "touch /tmp/pre-hook",
 		PostHook:      "touch /tmp/post-hook",
 		CfgFile:       "/etc/pg_back/pg_back.conf",
-		TimeFormat:    time.RFC3339,
+		TimeFormat:    timeFormat,
 	}
 
 	cliOptList := []string{

--- a/pg_back.conf
+++ b/pg_back.conf
@@ -10,7 +10,9 @@ backup_directory = /var/backups/postgresql
 
 # Timestamp format to use in filenames of output files. Two values are
 # possible: legacy and rfc3339. For example legacy is 2006-01-02_15-04-05, and
-# rfc3339 is 2006-01-02T15:04:05-07:00. rfc3339 is the default
+# rfc3339 is 2006-01-02T15:04:05-07:00. rfc3339 is the default, except on
+# Windows where it is not possible to use the rfs3339 format in filename. Thus
+# the only format on Windows is legacy: the option has no effect on Windows.
 # timestamp_format = rfc3339
 
 # PostgreSQL connection options. This are the usual libpq


### PR DESCRIPTION
To avoid forcing windows users to use a configuration file