### PR TITLE
Add quiet mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## pg_back 2.0.2
+
+* Add quiet mode with the commnad line option -q/--quiet. It takes precedence
+  over verbose mode.
+
 ## pg_back 2.0.1
 
 * Use /var/run/postgresql as default host for connections

--- a/config.go
+++ b/config.go
@@ -70,6 +70,7 @@ type options struct {
 	CfgFile       string
 	TimeFormat    string
 	Verbose       bool
+	Quiet         bool
 }
 
 func defaultOptions() options {
@@ -190,6 +191,7 @@ func parseCli(args []string) (options, []string, error) {
 	pflag.StringVarP(&opts.ConnDb, "dbname", "d", "", "connect to database name\n")
 	pflag.StringVar(&pce.LegacyConfig, "convert-legacy-config", "", "convert a pg_back v1 configuration file")
 	pflag.BoolVar(&pce.ShowConfig, "print-default-config", false, "print the default configuration\n")
+	pflag.BoolVarP(&opts.Quiet, "quiet", "q", false, "quiet mode")
 	pflag.BoolVarP(&opts.Verbose, "verbose", "v", false, "verbose mode\n")
 	pflag.BoolVarP(&pce.ShowHelp, "help", "?", false, "print usage")
 	pflag.BoolVarP(&pce.ShowVersion, "version", "V", false, "print version")

--- a/log.go
+++ b/log.go
@@ -35,6 +35,7 @@ import (
 type LevelLog struct {
 	logger  *log.Logger
 	verbose bool
+	quiet   bool
 }
 
 var l = NewLevelLog()
@@ -44,11 +45,20 @@ func NewLevelLog() *LevelLog {
 	return &LevelLog{
 		logger:  log.New(os.Stderr, "", log.LstdFlags|log.Lmsgprefix),
 		verbose: false,
+		quiet:   false,
 	}
 }
 
 // SetVerbose toggles verbose mode
-func (l *LevelLog) SetVerbose(verbose bool) {
+func (l *LevelLog) SetVerbosity(verbose bool, quiet bool) {
+	if quiet {
+		l.quiet = quiet
+		l.verbose = false
+
+		// Quiet mode takes over verbose mode
+		return
+	}
+
 	l.verbose = verbose
 	if verbose {
 		l.logger.SetFlags(log.LstdFlags | log.Lmsgprefix | log.Lmicroseconds)
@@ -73,14 +83,18 @@ func (l *LevelLog) Verboseln(v ...interface{}) {
 
 // Infof prints a message with INFO: prefix using log.Printf
 func (l *LevelLog) Infof(format string, v ...interface{}) {
-	l.logger.SetPrefix("INFO: ")
-	l.logger.Printf(format, v...)
+	if !l.quiet {
+		l.logger.SetPrefix("INFO: ")
+		l.logger.Printf(format, v...)
+	}
 }
 
 // Infoln prints a message with INFO: prefix using log.Println
 func (l *LevelLog) Infoln(v ...interface{}) {
-	l.logger.SetPrefix("INFO: ")
-	l.logger.Println(v...)
+	if !l.quiet {
+		l.logger.SetPrefix("INFO: ")
+		l.logger.Println(v...)
+	}
 }
 
 // Warnf prints a message with WARN: prefix using log.Printf

--- a/log_test.go
+++ b/log_test.go
@@ -38,7 +38,7 @@ func TestLevelLogSetVerbose(t *testing.T) {
 	l := NewLevelLog()
 	for i, subt := range tests {
 		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
-			l.SetVerbose(subt)
+			l.SetVerbosity(subt, false)
 			if l.verbose != subt {
 				t.Errorf("got %v, want %v", l.verbose, subt)
 			}
@@ -65,7 +65,7 @@ func TestLevelLogVerbose(t *testing.T) {
 		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
 			buf := new(bytes.Buffer)
 			l.logger.SetOutput(buf)
-			l.SetVerbose(subt.verbose)
+			l.SetVerbosity(subt.verbose, false)
 			if subt.fOrln {
 				l.Verbosef("%s", subt.message)
 			} else {
@@ -228,5 +228,38 @@ func TestLevelLogFatal(t *testing.T) {
 			}
 			l.logger.SetOutput(os.Stderr)
 		})
+	}
+}
+
+func TestLevelLogQuiet(t *testing.T) {
+	l := NewLevelLog()
+
+	// Set verbose and quiet to ensure quiet takes over verbose when both are true
+	l.SetVerbosity(true, true)
+
+	buf := new(bytes.Buffer)
+	l.logger.SetOutput(buf)
+
+	l.Verbosef("test")
+	if buf.Len() > 0 {
+		t.Errorf("log function Verbosef has printed data when it should not")
+	}
+
+	buf.Reset()
+	l.Verboseln("test")
+	if buf.Len() > 0 {
+		t.Errorf("log function Verboseln has printed data when it should not")
+	}
+
+	buf.Reset()
+	l.Infof("test")
+	if buf.Len() > 0 {
+		t.Errorf("log function Infof has printed data when it should not")
+	}
+
+	buf.Reset()
+	l.Infoln("test")
+	if buf.Len() > 0 {
+		t.Errorf("log function Infoln has printed data when it should not")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -127,8 +127,8 @@ func main() {
 		}
 	}
 
-	// Enable verbose mode as soon as possible
-	l.SetVerbose(cliOpts.Verbose)
+	// Enable verbose mode or quiet mode as soon as possible
+	l.SetVerbosity(cliOpts.Verbose, cliOpts.Quiet)
 
 	// Load configuration file and allow the default configuration
 	// file to be absent


### PR DESCRIPTION
Messages at VERBOSE and INFO levels can be silenced with the commnad line
option -q/--quiet. It is useful when run in cron to only get a mail when
errors are logged to stderr. When both verbose and quiet modes are set,
quiet mode takes precedence over verbose mode.

Closes #53 