### PR TITLE
Fix paths windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -713,6 +713,11 @@ func cleanDBName(dbname string) string {
 		dbname = strings.ReplaceAll(dbname, string(os.PathSeparator), "_")
 	}
 
+	// Always remove slashes to avoid issues with filenames on windows
+	if strings.ContainsRune(dbname, '/') {
+		dbname = strings.ReplaceAll(dbname, "/", "_")
+	}
+
 	return dbname
 }
 


### PR DESCRIPTION
This PR fixes some issues specific to windows:

* missing .exe when bin_directory is set
* escaping of db containing slashes in their name fails
* sftp puts backslashes in filenames
