### PR TITLE
fix purge based on a number to keep

### DIFF
--- a/main.go
+++ b/main.go
@@ -190,9 +190,11 @@ func run() (retVal error) {
 		return nil
 	}
 
-	// Remember when we start so that a purge interval of 0s won't remove the dumps we
-	// are taking
-	now := time.Now()
+	// Remember when we start so that a purge interval of 0s won't remove
+	// the dumps we are taking. We truncate the time to the second because
+	// the purge parses the date in the name of the file and its resolution
+	// is the second, thus the parsing truncates to the second.
+	now := time.Now().Truncate(time.Second)
 
 	if opts.BinDirectory != "" {
 		binDir = opts.BinDirectory


### PR DESCRIPTION
Purge of dumps while keeping a number of files did not make a difference
between dumps and other files like checksum, encrypted files or createdb
DDL script. So now, the files are first grouped by date to identify if
they were created by the run and the number of groups is used to compute
the number of dumps to keep.

closes #73 