### PR TITLE
pg_dump support compression natively with plain dump format too, use it.

### DIFF
--- a/purge.go
+++ b/purge.go
@@ -127,7 +127,7 @@ func purgeDumps(directory string, dbname string, keep int, limit time.Time) erro
 	// The dbname can be put in the path of the backup directory, so we
 	// have to compute it first. This is why a dbname is required to purge
 	// old dumps
-	dirpath := filepath.Dir(formatDumpPath(directory, "", "", dbname, time.Time{}))
+	dirpath := filepath.Dir(formatDumpPath(directory, "", "", dbname, time.Time{}, 0))
 	dir, err := os.Open(dirpath)
 	if err != nil {
 		return fmt.Errorf("could not purge %s: %s", dirpath, err)
@@ -211,7 +211,7 @@ func purgeRemoteDumps(repo Repo, directory string, dbname string, keep int, limi
 	// case the directory containing {dbname} in its name is kept on the
 	// remote path along with any subdirectory. So we have to include it in
 	// the filter when listing remote files
-	dirpath := filepath.Dir(formatDumpPath(directory, "", "", dbname, time.Time{}))
+	dirpath := filepath.Dir(formatDumpPath(directory, "", "", dbname, time.Time{}, 0))
 	prefix := relPath(directory, filepath.Join(dirpath, cleanDBName(dbname)))
 
 	// Get the list of files from the repository, this includes the

--- a/purge_test.go
+++ b/purge_test.go
@@ -61,7 +61,7 @@ func TestPurgeDumps(t *testing.T) {
 
 	// empty dbname
 	when := time.Now().Add(-time.Hour)
-	tf := formatDumpPath(wd, "2006-01-02_15-04-05", "dump", "", when)
+	tf := formatDumpPath(wd, "2006-01-02_15-04-05", "dump", "", when, 0)
 	f, err := os.Create(tf)
 	if err != nil {
 		t.Errorf("could not create temp file %s: %s", tf, err)
@@ -80,7 +80,7 @@ func TestPurgeDumps(t *testing.T) {
 
 	// file without write perms
 	if runtime.GOOS != "windows" {
-		tf = formatDumpPath(wd, time.RFC3339, "dump", "db", time.Now().Add(-time.Hour))
+		tf = formatDumpPath(wd, time.RFC3339, "dump", "db", time.Now().Add(-time.Hour), 0)
 		ioutil.WriteFile(tf, []byte("truc\n"), 0644)
 		os.Chmod(filepath.Dir(tf), 0555)
 
@@ -91,7 +91,7 @@ func TestPurgeDumps(t *testing.T) {
 		os.Chmod(filepath.Dir(tf), 0755)
 
 		// dir without write perms
-		tf = formatDumpPath(wd, time.RFC3339, "d", "db", time.Now().Add(-time.Hour))
+		tf = formatDumpPath(wd, time.RFC3339, "d", "db", time.Now().Add(-time.Hour), 0)
 		os.MkdirAll(tf, 0755)
 		os.Chmod(filepath.Dir(tf), 0555)
 
@@ -138,7 +138,7 @@ func TestPurgeDumps(t *testing.T) {
 			}
 			for i := 1; i <= 3; i++ {
 				when := time.Now().Add(-time.Hour * time.Duration(i))
-				tf = formatDumpPath(wd, st.format, "dump", "db", when)
+				tf = formatDumpPath(wd, st.format, "dump", "db", when, 0)
 				ioutil.WriteFile(tf, []byte("truc\n"), 0644)
 				os.Chtimes(tf, when, when)
 			}


### PR DESCRIPTION
Hi, pg_dump support the compression level option with plain sql format too.

Using this natively does not pass for a large SQL file on filesystem but is compressed "on the fly" by pg_dump itself.
Adapted the "formatDumpPath" function to append a ".gz" suffix in case there's the correct combination of options.
The compression is only applied to actual db dumps, for all others "dumps" seems unnecessary due to the relative small size of the output.