### PR TITLE
AGE encryption and decryption with asymmetric keys

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -28,15 +28,16 @@ package main
 import (
 	"errors"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/spf13/pflag"
-	"gopkg.in/ini.v1"
 	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/spf13/pflag"
+	"gopkg.in/ini.v1"
 )
 
 func TestValidateDumpFormat(t *testing.T) {
@@ -311,6 +312,102 @@ func TestParseCli(t *testing.T) {
 				false,
 				false,
 				"invalid value for --upload: value not found in [none s3 sftp gcs azure]",
+				"",
+			},
+			{
+				[]string{"--decrypt", "--encrypt"},
+				defaults,
+				false,
+				false,
+				"options --encrypt and --decrypt are mutually exclusive",
+				"",
+			},
+			{
+				[]string{"--cipher-pass", "mypass"},
+				options{
+					Directory:        "/var/backups/postgresql",
+					Format:           'c',
+					DirJobs:          1,
+					CompressLevel:    -1,
+					Jobs:             1,
+					PauseTimeout:     3600,
+					PurgeInterval:    -30 * 24 * time.Hour,
+					PurgeKeep:        0,
+					SumAlgo:          "none",
+					CfgFile:          "/etc/pg_back/pg_back.conf",
+					TimeFormat:       timeFormat,
+					Decrypt:          false,
+					CipherPassphrase: "mypass",
+					Upload:           "none",
+					AzureEndpoint:    "blob.core.windows.net",
+				},
+				false,
+				false,
+				"",
+				"",
+			},
+			{
+				[]string{"--cipher-private-key", "mykey"},
+				options{
+					Directory:        "/var/backups/postgresql",
+					Format:           'c',
+					DirJobs:          1,
+					CompressLevel:    -1,
+					Jobs:             1,
+					PauseTimeout:     3600,
+					PurgeInterval:    -30 * 24 * time.Hour,
+					PurgeKeep:        0,
+					SumAlgo:          "none",
+					CfgFile:          "/etc/pg_back/pg_back.conf",
+					TimeFormat:       timeFormat,
+					Decrypt:          false,
+					CipherPrivateKey: "mykey",
+					Upload:           "none",
+					AzureEndpoint:    "blob.core.windows.net",
+				},
+				false,
+				false,
+				"",
+				"",
+			},
+			{
+				[]string{"--cipher-public-key", "fakepubkey"},
+				options{
+					Directory:       "/var/backups/postgresql",
+					Format:          'c',
+					DirJobs:         1,
+					CompressLevel:   -1,
+					Jobs:            1,
+					PauseTimeout:    3600,
+					PurgeInterval:   -30 * 24 * time.Hour,
+					PurgeKeep:       0,
+					SumAlgo:         "none",
+					CfgFile:         "/etc/pg_back/pg_back.conf",
+					TimeFormat:      timeFormat,
+					Decrypt:         false,
+					CipherPublicKey: "fakepubkey",
+					Upload:          "none",
+					AzureEndpoint:   "blob.core.windows.net",
+				},
+				false,
+				false,
+				"",
+				"",
+			},
+			{
+				[]string{"--cipher-pass", "whee", "--cipher-private-key", "anotherkey"},
+				defaults,
+				false,
+				false,
+				"only one of --cipher-pass or --cipher-private-key allowed",
+				"",
+			},
+			{
+				[]string{"--cipher-pass", "wahoo", "--cipher-public-key", "thisisakey"},
+				defaults,
+				false,
+				false,
+				"only one of --cipher-pass or --cipher-public-key allowed",
 				"",
 			},
 		}

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -1,0 +1,260 @@
+// pg_back
+//
+// Copyright 2011-2021 Nicolas Thauvin and contributors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  1. Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+// OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+// IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+// INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+// THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package main
+
+import (
+	"bytes"
+	b64 "encoding/base64"
+	"strings"
+	"testing"
+
+	"filippo.io/age"
+)
+
+const TEST_PRIVATE_KEY = "AGE-SECRET-KEY-1XLVVN6PHUZNFFFRA0AGLEJ22GWDGN6WG8KFDV56FH5DC9P2Y8F2SPH8W44"
+const TEST_PUBLIC_KEY = "age1702xupy5u4d6a5z2dwcn9e2th4mqpth5kvl3nmhq063gf70d9awsl37jn6"
+const TEST_ENCRYPTED_FILE_BASE64 = "YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzanBtS3hmUGQwekNER0hwWjNod1Z2Y1FCVEZGMkExdmRlcS9vUy8vTEZBClgvOXB3QjRLN2E3aERGUmFMSXdiM3h4R0JFTytwb0hsSEpJV0NTVk1mME0KLS0tIHpqSnRhc0F6NEZ6b0R6aEl5U0V3cnNmL2pKRWVwNHd3dU9wdExjeWx0Tk0KL9m6JZXXAeEZBA7w7nuyrl4ztjY2+Ypu1GNrL6bjv7aw+ACqVGZZwLDI6Q=="
+const TEST_PLAINTEXT_FILE = "test string"
+
+func TestAgeEncrypt_NilParams_Failure(t *testing.T) {
+	content := "to be encrypted"
+	reader := strings.NewReader(content)
+	writer := &bytes.Buffer{}
+	params := encryptParams{}
+
+	err := ageEncrypt(reader, writer, params)
+	if err == nil {
+		t.Errorf("Expected empty encryption params to fail")
+	}
+}
+
+func TestAgeDecrypt_NilParams_Failure(t *testing.T) {
+	content := "to be encrypted"
+	reader := strings.NewReader(content)
+	writer := &bytes.Buffer{}
+	params := decryptParams{}
+
+	err := ageDecrypt(reader, writer, params)
+	if err == nil {
+		t.Errorf("Expected empty encryption params to fail")
+	}
+}
+
+func TestAgeDecrypt_InvalidPrivateKey_Failure(t *testing.T) {
+	encrypted, err := b64.StdEncoding.DecodeString(TEST_ENCRYPTED_FILE_BASE64)
+	if err != nil {
+		t.Fatalf("could not decode golden string")
+	}
+	reader := bytes.NewReader(encrypted)
+	writer := &bytes.Buffer{}
+	params := decryptParams{PrivateKey: TEST_PUBLIC_KEY}
+
+	err = ageDecrypt(reader, writer, params)
+	if err == nil {
+		t.Errorf("Expected invalid private key to fail")
+	}
+}
+
+func TestAgeDecrypt_InvalidPublicKey_Failure(t *testing.T) {
+	content := "to be encrypted"
+	reader := strings.NewReader(content)
+	writer := &bytes.Buffer{}
+	params := decryptParams{PrivateKey: TEST_PRIVATE_KEY}
+
+	err := ageDecrypt(reader, writer, params)
+	if err == nil {
+		t.Errorf("Expected invalid public key to fail")
+	}
+}
+
+func TestAgeEncryptPassphrase_EmptyPassphrase_Failure(t *testing.T) {
+	content := "to be encrypted"
+	reader := strings.NewReader(content)
+	writer := &bytes.Buffer{}
+
+	err := ageEncryptPassphrase(reader, writer, "")
+	if err == nil {
+		t.Errorf("Expected empty passphrase to fail")
+	}
+}
+
+func TestAgeDecryptPassphrase_EmptyPassphrase_Failure(t *testing.T) {
+	encrypted, err := b64.StdEncoding.DecodeString(TEST_ENCRYPTED_FILE_BASE64)
+	if err != nil {
+		t.Fatalf("could not decode golden string")
+	}
+	reader := bytes.NewReader(encrypted)
+	writer := &bytes.Buffer{}
+
+	err = ageDecryptPassphrase(reader, writer, "")
+	if err == nil {
+		t.Errorf("Expected empty passphrase to fail")
+	}
+}
+
+func TestAgeDecrypt_Golden_Success(t *testing.T) {
+	encrypted, err := b64.StdEncoding.DecodeString(TEST_ENCRYPTED_FILE_BASE64)
+	if err != nil {
+		t.Fatalf("could not decode golden string")
+	}
+	reader := bytes.NewReader(encrypted)
+	writer := &bytes.Buffer{}
+	params := decryptParams{
+		PrivateKey: TEST_PRIVATE_KEY,
+	}
+
+	err = ageDecrypt(reader, writer, params)
+	if err != nil {
+		t.Fatalf("could not decrypt golden message: %v", err)
+	}
+
+	if writer.String() != TEST_PLAINTEXT_FILE {
+		t.Errorf("got %v want %v", writer.String(), TEST_PLAINTEXT_FILE)
+	}
+}
+
+func TestAgeEncrypt_PublicKey_Loopback_Success(t *testing.T) {
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("Failed to generate key pair: %v", err)
+	}
+
+	content := "to be encrypted"
+	reader := strings.NewReader(content)
+	writer := &bytes.Buffer{}
+	params := encryptParams{PublicKey: identity.Recipient().String()}
+
+	err = ageEncrypt(reader, writer, params)
+	if err != nil {
+		t.Errorf("Unexpected error when encrypting")
+	}
+
+	ciphertext := writer.String()
+	if ciphertext == "" {
+		t.Errorf("encrypted output is empty")
+	}
+
+	reader = strings.NewReader(ciphertext)
+	writer = &bytes.Buffer{}
+	decryptParams := decryptParams{PrivateKey: identity.String()}
+	err = ageDecrypt(reader, writer, decryptParams)
+	if err != nil {
+		t.Errorf("Unexpected error when decrypting")
+	}
+
+	if writer.String() != content {
+		t.Errorf("Did not decrypt to same plaintext")
+	}
+}
+
+func TestAgeEncrypt_Passphrase_Loopback_Success(t *testing.T) {
+	content := "to be encrypted"
+	reader := strings.NewReader(content)
+	writer := &bytes.Buffer{}
+	params := encryptParams{Passphrase: "supersecret"}
+
+	err := ageEncrypt(reader, writer, params)
+	if err != nil {
+		t.Errorf("Unexpected error when encrypting")
+	}
+
+	ciphertext := writer.String()
+	if ciphertext == "" {
+		t.Errorf("encrypted output is empty")
+	}
+
+	reader = strings.NewReader(ciphertext)
+	writer = &bytes.Buffer{}
+	decryptParams := decryptParams{Passphrase: "supersecret"}
+	err = ageDecrypt(reader, writer, decryptParams)
+	if err != nil {
+		t.Errorf("Unexpected error when decrypting")
+	}
+
+	if writer.String() != content {
+		t.Errorf("Did not decrypt to same plaintext")
+	}
+}
+
+func TestAgeEncrypt_WrongPrivateKey_Loopback_Failure(t *testing.T) {
+	identity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("Failed to generate key pair: %v", err)
+	}
+
+	content := "to be encrypted"
+	reader := strings.NewReader(content)
+	writer := &bytes.Buffer{}
+	params := encryptParams{PublicKey: identity.Recipient().String()}
+
+	err = ageEncrypt(reader, writer, params)
+	if err != nil {
+		t.Errorf("Unexpected error when encrypting")
+	}
+
+	ciphertext := writer.String()
+	if ciphertext == "" {
+		t.Errorf("encrypted output is empty")
+	}
+
+	wrongIdentity, err := age.GenerateX25519Identity()
+	if err != nil {
+		t.Fatalf("Failed to generate key pair: %v", err)
+	}
+
+	reader = strings.NewReader(ciphertext)
+	writer = &bytes.Buffer{}
+	decryptParams := decryptParams{PrivateKey: wrongIdentity.String()}
+	err = ageDecrypt(reader, writer, decryptParams)
+	if err == nil {
+		t.Errorf("Decryption should have failed")
+	}
+}
+
+func TestAgeEncrypt_WrongPassphrase_Loopback_Failure(t *testing.T) {
+	content := "to be encrypted"
+	reader := strings.NewReader(content)
+	writer := &bytes.Buffer{}
+	params := encryptParams{Passphrase: "supersecret"}
+
+	err := ageEncrypt(reader, writer, params)
+	if err != nil {
+		t.Errorf("Unexpected error when encrypting")
+	}
+
+	ciphertext := writer.String()
+	if ciphertext == "" {
+		t.Errorf("encrypted output is empty")
+	}
+
+	reader = strings.NewReader(ciphertext)
+	writer = &bytes.Buffer{}
+	decryptParams := decryptParams{Passphrase: "wrong"}
+	err = ageDecrypt(reader, writer, decryptParams)
+	if err == nil {
+		t.Fatalf("Decryption should have failed")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -162,7 +162,7 @@ func run() (retVal error) {
 	// the command line
 	opts := mergeCliAndConfigOptions(cliOpts, configOpts, cliOptList)
 
-	err = ensureCipherParamsPresent(opts)
+	err = ensureCipherParamsPresent(&opts)
 	if err != nil {
 		return fmt.Errorf("required cipher parameters not present: %w", err)
 	}
@@ -681,7 +681,7 @@ func dumper(id int, jobs <-chan *dump, results chan<- *dump, fc chan<- sumFileJo
 	}
 }
 
-func ensureCipherParamsPresent(opts options) error {
+func ensureCipherParamsPresent(opts *options) error {
 	// Nothing needs to be done if we are not encrypting or decrypting
 	if !opts.Encrypt && !opts.Decrypt {
 		return nil

--- a/main_test.go
+++ b/main_test.go
@@ -68,3 +68,53 @@ func TestExecPath(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureCipherParamsPresent_NoEncryptNoDecrypt_NoParams_ReturnsNil(t *testing.T) {
+	opts := options{}
+
+	err := ensureCipherParamsPresent(&opts)
+	if err != nil {
+		t.Errorf("should not return error")
+	}
+}
+
+func TestEnsureCipherParamsPresent_NoEncryptNoDecrypt_HasParams_ReturnsNil(t *testing.T) {
+	opts := options{
+		CipherPublicKey:  "foo1",
+		CipherPrivateKey: "bar99",
+		CipherPassphrase: "secretwords",
+	}
+
+	err := ensureCipherParamsPresent(&opts)
+	if err != nil {
+		t.Errorf("should not return error")
+	}
+}
+
+func TestEnsureCipherParamsPresent_Encrypt_NoParams_Failure(t *testing.T) {
+	opts := options{
+		Encrypt:          true,
+		CipherPrivateKey: "bar99",
+	}
+
+	err := ensureCipherParamsPresent(&opts)
+	if err == nil {
+		t.Errorf("should have error about not finding passphrase")
+	}
+}
+
+func TestEnsureCipherParamsPresent_Encrypt_NoParamsButEnv_Success(t *testing.T) {
+	opts := options{
+		Encrypt: true,
+	}
+	t.Setenv("PGBK_CIPHER_PASS", "works")
+
+	err := ensureCipherParamsPresent(&opts)
+	if err != nil {
+		t.Errorf("should have read environment variable")
+	}
+
+	if opts.CipherPassphrase != "works" {
+		t.Errorf("passphrase was not read correctly from environment")
+	}
+}


### PR DESCRIPTION
This allows pg_back to encrypt the backups using a public key only. This has the advantage of not leaking the decryption key for other backups if an attacker gains access to the backup system.

This helps with the Kubernetes usecase where the secret may be long-lived and we want to minimize attack surface when some part of the system is compromised.