### PR TITLE
pg_back.conf: typos, spelling, points

### DIFF
--- a/pg_back.conf
+++ b/pg_back.conf
@@ -42,15 +42,15 @@ with_templates = false
 format = custom
 
 # When the format is directory, number of parallel jobs to dumps (-j
-# option of pg_dump)
+# option of pg_dump).
 parallel_backup_jobs = 1
 
 # When using a compressed binary format, e.g. custom or directory, adjust the
 # compression level between 0 and 9. Use -1 to keep the default level of pg_dump.
 compress_level = -1
 
-# Compute checksum a checksum file for each dump that can be checked
-# by the corresponding shaXsum -c command. Possible values are none to
+# Compute a checksum for each file in the dumps. It can be checked
+# by the corresponding shaXsum -c command. Possible values are: none to
 # disable checksums, sha1, sha224, sha256, sha384, and sha512.
 checksum_algorithm = none
 
@@ -61,23 +61,23 @@ encrypt = false
 # environment variable can be used alternatively.
 cipher_pass =
 
-# Keep orignal files after encrypting them.
+# Keep original files after encrypting them.
 encrypt_keep_source = false
 
 # Purge dumps older than this number of days. If the interval has to
 # be shorter than one day, use a duration with units, h for hours, m
 # for minutes, s for seconds, us for microseconds or ns for
-# nanoseconds, ex. 1h30m24s.
+# nanoseconds, e.g. 1h30m24s.
 purge_older_than = 30
 
 # When purging older dumps, always keep this minimum number of
-# dumps. The default is 0, even if purge_older_than is 0 the dumps of
-# the current run are kept, if one wants to remove all dumps and not
+# dumps. The default is 0. Even if purge_older_than is 0 the dumps of
+# the current run are kept. To remove all dumps and not
 # keep anything, for example to just test for data corruption, then
 # purge_older_than shall be a negative duration.
 purge_min_keep = 0
 
-# Number of pg_dump commands to run concurrently
+# Number of pg_dump commands to run concurrently.
 jobs = 1
 
 # inject these options to pg_dump
@@ -86,11 +86,11 @@ pg_dump_options =
 # When dumping from a hot standby server, wait for exclusive locks to
 # be released within this number of seconds. Abort if exclusive locks
 # are still held. If a exclusive lock is granted and replication is
-# paused, the lock is held until to replication is resumed, causing
+# paused, the lock is held until the replication is resumed, causing
 # pg_dump to wait forever.
 pause_timeout = 3600
 
-# Commands to execute before dumping and after. The post-backup
+# Commands to execute before and after dumping. The post-backup
 # command is always executed even in case of failure.
 pre_backup_hook = 
 post_backup_hook =
@@ -100,7 +100,7 @@ post_backup_hook =
 upload = none
 
 # Purge remote files. When uploading to a remote location, purge the remote
-# files with the same rules as the local directory
+# files with the same rules as the local directory.
 # purge_remote = false
 
 # AWS S3 Access information. Region and Bucket are mandatory. If no credential
@@ -149,7 +149,7 @@ upload = none
 # azure_key =
 
 # # Per database options. Use a ini section named the same as the
-# # database. These options take precedence over the global values
+# # database. These options take precedence over the global values.
 # [dbname]
 
 # format =
@@ -161,7 +161,7 @@ upload = none
 
 # # List of schemas and tables to dump or exlude from the dump.
 # # Inclusion and exclusion rules of pg_dump apply, as well as
-# # pattern rules. Separate schema/table names with a semicolon
+# # pattern rules. Separate schema/table names with a semicolon.
 # schemas =
 # exclude_schemas =
 
@@ -172,7 +172,7 @@ upload = none
 # keep the default behaviour, see pg_dump -b.
 # with_blobs = true
 
-# # inject these options to pg_dump. Use an empty value to cancel the
-# # global value of pg_dump_options
+# # inject these options to pg_dump. Use an empty value to override the
+# # global value of pg_dump_options.
 # pg_dump_options =
 


### PR DESCRIPTION
A few cosmetic changes in the comments of pg_back.conf, including a typo and points at the end of sentences