### PR TITLE
fix documentation, use comma instead of semicolon

### DIFF
--- a/pg_back.conf
+++ b/pg_back.conf
@@ -161,7 +161,7 @@ upload = none
 
 # # List of schemas and tables to dump or exlude from the dump.
 # # Inclusion and exclusion rules of pg_dump apply, as well as
-# # pattern rules. Separate schema/table names with a semicolon.
+# # pattern rules. Separate schema/table names with a comma.
 # schemas =
 # exclude_schemas =
 


### PR DESCRIPTION
I forgot to change the doc in my last PR.


