### PR TITLE
Add the --dump-only option to only dump databases

### DIFF
--- a/main.go
+++ b/main.go
@@ -704,7 +704,14 @@ func (d *dump) dump(fc chan<- sumFileJob) error {
 	d.Path = file
 	d.ExitCode = 0
 
-	if err := os.Chmod(file, 0600); err != nil {
+	var mode os.FileMode = 0600
+	if d.Options.Format == 'd' {
+		// The hardening of permissions only apply to the top level
+		// directory, this won't make the contents executable
+		mode = 0700
+	}
+
+	if err := os.Chmod(file, mode); err != nil {
 		return fmt.Errorf("could not chmod to more secure permission for %s: %s", dbname, err)
 	}
 

--- a/pg_back.conf
+++ b/pg_back.conf
@@ -40,6 +40,9 @@ exclude_dbs =
 # include_dbs is empty.
 with_templates = false
 
+# Dump only databases, excluding configuration and globals
+dump_only = false
+
 # Format of the dump, understood by pg_dump. Possible values are
 # plain, custom, tar or directory.
 format = custom


### PR DESCRIPTION
The new option --dump-only allows skipping dumps of configuration and globals, including database ACL and configuration when pg_dump is older than 11. More than one file can still be created, for example if checksum are enabled. The corresponding configuration parameter is dump_only, it is false by default.