### PR TITLE
Add an option to configure permission on dump

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -62,6 +62,35 @@ func TestValidateDumpFormat(t *testing.T) {
 
 }
 
+func TestValidateMode(t *testing.T) {
+	var tests = []struct {
+		give      string
+		want      int
+		wantError bool
+	}{
+		{"0700", 448, false},
+		{"070000", 0, true},      // invalid mode (too long)
+		{"18446744000", 0, true}, // still invalid, positive integer
+		{"08170", 0, true},       // non valid mode (8 on it)
+		{"-8170", -8170, false},  // valid and mean do nothing (useful when using umask)
+	}
+
+	l.logger.SetOutput(ioutil.Discard)
+	for i, st := range tests {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			got, err := validateMode(st.give)
+			if err == nil && st.wantError {
+				t.Errorf("excepted an error got nil")
+			} else if err != nil && !st.wantError {
+				t.Errorf("did not want an error, got %s", err)
+			}
+			if got != st.want {
+				t.Errorf("got %v, want %v", got, st.want)
+			}
+		})
+	}
+}
+
 func TestValidatePurgeKeepValue(t *testing.T) {
 	var tests = []struct {
 		give      string
@@ -183,6 +212,7 @@ func TestDefaultOptions(t *testing.T) {
 
 	var want = options{
 		Directory:               "/var/backups/postgresql",
+		Mode:                    0o600,
 		Format:                  'c',
 		DirJobs:                 1,
 		CompressLevel:           -1,
@@ -228,6 +258,7 @@ func TestParseCli(t *testing.T) {
 				[]string{"-b", "test", "-Z", "2", "a", "b"},
 				options{
 					Directory:               "test",
+					Mode:                    0o600,
 					Dbnames:                 []string{"a", "b"},
 					Format:                  'c',
 					DirJobs:                 1,
@@ -255,6 +286,7 @@ func TestParseCli(t *testing.T) {
 				[]string{"-t", "--without-templates"},
 				options{
 					Directory:               "/var/backups/postgresql",
+					Mode:                    0o600,
 					WithTemplates:           false,
 					Format:                  'c',
 					DirJobs:                 1,
@@ -306,6 +338,7 @@ func TestParseCli(t *testing.T) {
 				[]string{"--upload", "wrong"},
 				options{
 					Directory:               "/var/backups/postgresql",
+					Mode:                    0o600,
 					Format:                  'c',
 					DirJobs:                 1,
 					CompressLevel:           -1,
@@ -334,6 +367,7 @@ func TestParseCli(t *testing.T) {
 				[]string{"--download", "wrong"},
 				options{
 					Directory:               "/var/backups/postgresql",
+					Mode:                    0o600,
 					Format:                  'c',
 					DirJobs:                 1,
 					CompressLevel:           -1,
@@ -370,6 +404,7 @@ func TestParseCli(t *testing.T) {
 				[]string{"--cipher-pass", "mypass"},
 				options{
 					Directory:               "/var/backups/postgresql",
+					Mode:                    0o600,
 					Format:                  'c',
 					DirJobs:                 1,
 					CompressLevel:           -1,
@@ -398,6 +433,7 @@ func TestParseCli(t *testing.T) {
 				[]string{"--cipher-private-key", "mykey"},
 				options{
 					Directory:               "/var/backups/postgresql",
+					Mode:                    0o600,
 					Format:                  'c',
 					DirJobs:                 1,
 					CompressLevel:           -1,
@@ -426,6 +462,7 @@ func TestParseCli(t *testing.T) {
 				[]string{"--cipher-public-key", "fakepubkey"},
 				options{
 					Directory:               "/var/backups/postgresql",
+					Mode:                    0o600,
 					Format:                  'c',
 					DirJobs:                 1,
 					CompressLevel:           -1,
@@ -538,10 +575,11 @@ func TestLoadConfigurationFile(t *testing.T) {
 		want   options
 	}{
 		{
-			[]string{"backup_directory = test", "port = 5433"},
+			[]string{"backup_directory = test", "port = 5433", "backup_file_mode = 0700"},
 			false,
 			options{
 				Directory:               "test",
+				Mode:                    0o700,
 				Port:                    5433,
 				Format:                  'c',
 				DirJobs:                 1,
@@ -562,10 +600,11 @@ func TestLoadConfigurationFile(t *testing.T) {
 			},
 		},
 		{ // ensure comma separated lists work
-			[]string{"backup_directory = test", "include_dbs = a, b, postgres", "compress_level = 9"},
+			[]string{"backup_directory = test", "include_dbs = a, b, postgres", "compress_level = 9", "backup_file_mode = 0400"},
 			false,
 			options{
 				Directory:               "test",
+				Mode:                    0o400,
 				Dbnames:                 []string{"a", "b", "postgres"},
 				Format:                  'c',
 				DirJobs:                 1,
@@ -590,6 +629,7 @@ func TestLoadConfigurationFile(t *testing.T) {
 			false,
 			options{
 				Directory:               "/var/backups/postgresql",
+				Mode:                    0o600,
 				Format:                  'c',
 				DirJobs:                 1,
 				CompressLevel:           -1,
@@ -613,6 +653,7 @@ func TestLoadConfigurationFile(t *testing.T) {
 			false,
 			options{
 				Directory:               "/var/backups/postgresql",
+				Mode:                    0o600,
 				Format:                  'c',
 				DirJobs:                 1,
 				CompressLevel:           -1,
@@ -654,6 +695,7 @@ func TestLoadConfigurationFile(t *testing.T) {
 			false,
 			options{
 				Directory:     "test",
+				Mode:          0o600,
 				Format:        'c',
 				DirJobs:       1,
 				CompressLevel: -1,
@@ -698,6 +740,7 @@ func TestLoadConfigurationFile(t *testing.T) {
 			false,
 			options{
 				Directory:     "test",
+				Mode:          0o600,
 				Format:        'c',
 				DirJobs:       1,
 				CompressLevel: 3,
@@ -774,6 +817,7 @@ func TestMergeCliAndConfigoptions(t *testing.T) {
 	want := options{
 		BinDirectory:            "/bin",
 		Directory:               "test",
+		Mode:                    0o600,
 		Host:                    "localhost",
 		Port:                    5433,
 		Username:                "test",

--- a/crypto.go
+++ b/crypto.go
@@ -130,7 +130,7 @@ func ageDecryptInternal(src io.Reader, dst io.Writer, identity age.Identity) err
 	return nil
 }
 
-func encryptFile(path string, params encryptParams, keep bool) ([]string, error) {
+func encryptFile(path string, mode int, params encryptParams, keep bool) ([]string, error) {
 	encrypted := make([]string, 0)
 
 	i, err := os.Stat(path)
@@ -210,7 +210,11 @@ func encryptFile(path string, params encryptParams, keep bool) ([]string, error)
 		}
 
 		encrypted = append(encrypted, dstFile)
-
+		if mode > 0 {
+			if err := os.Chmod(dstFile, os.FileMode(mode)); err != nil {
+				return encrypted, fmt.Errorf("could not chmod to more secure permission for encrypted file: %w", err)
+			}
+		}
 		if !keep {
 			l.Verboseln("removing source file:", path)
 			src.Close()

--- a/hash.go
+++ b/hash.go
@@ -51,7 +51,7 @@ func computeChecksum(path string, h hash.Hash) (string, error) {
 	return string(h.Sum(nil)), nil
 }
 
-func checksumFile(path string, algo string) (string, error) {
+func checksumFile(path string, mode int, algo string) (string, error) {
 	var h hash.Hash
 
 	switch algo {
@@ -114,10 +114,16 @@ func checksumFile(path string, algo string) (string, error) {
 		r, _ := computeChecksum(path, h)
 		fmt.Fprintf(o, "%x  %s\n", r, path)
 	}
+	l.Verboseln("computing checksum with MODE", mode, path)
+	if mode > 0 {
+		if err := os.Chmod(o.Name(), os.FileMode(mode)); err != nil {
+			return "", fmt.Errorf("could not chmod checksum file %s: %s", path, err)
+		}
+	}
 	return sumFile, nil
 }
 
-func checksumFileList(paths []string, algo string, sumFilePrefix string) (string, error) {
+func checksumFileList(paths []string, mode int, algo string, sumFilePrefix string) (string, error) {
 	var h hash.Hash
 
 	switch algo {
@@ -157,6 +163,12 @@ func checksumFileList(paths []string, algo string, sumFilePrefix string) (string
 		}
 
 		fmt.Fprintf(o, "%x *%s\n", r, path)
+
+		if mode > 0 {
+			if err := os.Chmod(o.Name(), os.FileMode(mode)); err != nil {
+				return "", fmt.Errorf("could not chmod checksum file %s: %s", path, err)
+			}
+		}
 	}
 
 	if failed {

--- a/hash_test.go
+++ b/hash_test.go
@@ -77,18 +77,18 @@ func TestChecksumFile(t *testing.T) {
 	}
 
 	// bad algo
-	if _, err := checksumFile("", "none"); err != nil {
+	if _, err := checksumFile("", 0o700, "none"); err != nil {
 		t.Errorf("expected <nil>, got %q\n", err)
 	}
 
-	if _, err := checksumFile("", "other"); err == nil {
+	if _, err := checksumFile("", 0o700, "other"); err == nil {
 		t.Errorf("expected err, got <nil>\n")
 	}
 
 	// test each algo with the file
 	for i, st := range tests {
 		t.Run(fmt.Sprintf("f%v", i), func(t *testing.T) {
-			if _, err := checksumFile("test", st.algo); err != nil {
+			if _, err := checksumFile("test", 0o700, st.algo); err != nil {
 				t.Errorf("checksumFile returned: %v", err)
 			}
 
@@ -111,12 +111,12 @@ func TestChecksumFile(t *testing.T) {
 	// bad files
 	var e *os.PathError
 	l.logger.SetOutput(ioutil.Discard)
-	if _, err := checksumFile("", "sha1"); !errors.As(err, &e) {
+	if _, err := checksumFile("", 0o700, "sha1"); !errors.As(err, &e) {
 		t.Errorf("expected an *os.PathError, got %q\n", err)
 	}
 
 	os.Chmod("test.sha1", 0444)
-	if _, err := checksumFile("test", "sha1"); !errors.As(err, &e) {
+	if _, err := checksumFile("test", 0o700, "sha1"); !errors.As(err, &e) {
 		t.Errorf("expected an *os.PathError, got %q\n", err)
 	}
 	os.Chmod("test.sha1", 0644)
@@ -138,7 +138,7 @@ func TestChecksumFile(t *testing.T) {
 	// test each algo with the directory
 	for i, st := range tests {
 		t.Run(fmt.Sprintf("d%v", i), func(t *testing.T) {
-			if _, err := checksumFile("test.d", st.algo); err != nil {
+			if _, err := checksumFile("test.d", 0o700, st.algo); err != nil {
 				t.Errorf("checksumFile returned: %v", err)
 			}
 

--- a/pg_back.conf
+++ b/pg_back.conf
@@ -8,6 +8,16 @@ bin_directory =
 # being dumped.
 backup_directory = /var/backups/postgresql
 
+# Mode  permissions to apply to database dumps after the dump is completed.
+# This parameter uses Unix file permission chmod / mode with an octal
+# representation (Example: 0700 or 0600). A negative value can be used to
+# disable modifying permission and let the system handle that (example when
+# umask is defined). When the format is set to directory, pg_back ensures
+# the top-level directory is traversable by adding execute (+x) permission
+# if read (r) or write (w) permission is set. This does not affect the
+# permissions of files inside the directory.
+backup_file_mode = 0600
+
 # Timestamp format to use in filenames of output files. Two values are
 # possible: legacy and rfc3339. For example legacy is 2006-01-02_15-04-05, and
 # rfc3339 is 2006-01-02T15:04:05-07:00. rfc3339 is the default, except on


### PR DESCRIPTION
We add an option / configuration item to define the permissions for the dumps created with pg_back. We reuse / configure the 0600 permissions by default to ensure some compatibility with the old (non configurable) approach.

We probably need to discuss and improve what we should do for the parent directory when using 'd' for the dump format. Currently we still apply the 0700 mode in such situation, but maybe we should define a specific option or reuse the one we add right now.