### PR TITLE
Add upload_prefix option to pg_back.conf example file

### DIFF
--- a/pg_back.conf
+++ b/pg_back.conf
@@ -111,6 +111,11 @@ post_backup_hook =
 # s3, sftp, gcs. The default is none, meaning no file will be uploaded.
 upload = none
 
+# The upload_prefix option can be used to place the files in a remote
+# directory, as most cloud storage treat prefix as directories. The filename and
+# the prefix is separated by a / in the remote location.
+upload_prefix = ""
+
 # Purge remote files. When uploading to a remote location, purge the remote
 # files with the same rules as the local directory.
 # purge_remote = false


### PR DESCRIPTION
Commit 5a23505 added the upload_prefix functionality but the example pg_back.conf file wasn't updated to include it. This commit fixes this oversight.