### PR TITLE
Replace for loop with counter by range

### DIFF
--- a/connstring.go
+++ b/connstring.go
@@ -450,13 +450,13 @@ func makeUrlConnInfo(infos map[string]string) string {
 				// same non default port for all hosts, duplicate it
 				// for the next loop
 				if ports[0] != "" {
-					for i := 0; i < len(hosts); i++ {
+					for range len(hosts) {
 						ports = append(ports, ports[0])
 					}
 				}
 			} else {
 				// fill with empty port to fix the list
-				for i := 0; i < len(hosts); i++ {
+				for range len(hosts) {
 					ports = append(ports, "")
 				}
 			}

--- a/hash_test.go
+++ b/hash_test.go
@@ -126,7 +126,7 @@ func TestChecksumFile(t *testing.T) {
 	if err := os.Mkdir("test.d", 0755); err != nil {
 		t.Fatal("could not create test dir")
 	}
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		f, err := os.Create(filepath.Join("test.d", fmt.Sprintf("test%d", i)))
 		if err != nil {
 			t.Fatal("could not create test file")

--- a/main.go
+++ b/main.go
@@ -356,8 +356,8 @@ func run() (retVal error) {
 
 	// start workers - thanks gobyexample.com
 	l.Verbosef("launching %d workers", maxWorkers)
-	for w := 0; w < maxWorkers; w++ {
-		go dumper(w, jobs, results, producedFiles)
+	for range maxWorkers {
+		go dumper(jobs, results, producedFiles)
 	}
 
 	defDbOpts := defaultDbOpts(opts)
@@ -404,7 +404,7 @@ func run() (retVal error) {
 	}
 
 	// collect the result of the jobs
-	for j := 0; j < numJobs; j++ {
+	for range numJobs {
 		var b, c string
 		var err error
 
@@ -754,7 +754,7 @@ func (d *dump) dump(fc chan<- sumFileJob) error {
 	return nil
 }
 
-func dumper(id int, jobs <-chan *dump, results chan<- *dump, fc chan<- sumFileJob) {
+func dumper(jobs <-chan *dump, results chan<- *dump, fc chan<- sumFileJob) {
 	for j := range jobs {
 
 		if err := j.dump(fc); err != nil {
@@ -1138,7 +1138,7 @@ func decryptDirectory(dir string, params decryptParams, workers int, globs []str
 
 	// Start workers that listen for filenames to decrypt until the queue
 	// is closed
-	for i := 0; i < workers; i++ {
+	for i := range workers {
 		wg.Add(1)
 		go func(id int) {
 			l.Verboseln("started decrypt worker", id)
@@ -1324,7 +1324,7 @@ func postProcessFiles(inFiles chan sumFileJob, wg *sync.WaitGroup, opts options)
 	encIn := make(chan encryptFileJob)
 	uploadIn := make(chan uploadJob)
 
-	for i := 0; i < opts.Jobs; i++ {
+	for i := range opts.Jobs {
 		wg.Add(1)
 		go func(id int) {
 			l.Verboseln("started checksum worker", id)
@@ -1427,7 +1427,7 @@ func postProcessFiles(inFiles chan sumFileJob, wg *sync.WaitGroup, opts options)
 
 	sumEncIn := make(chan sumEncryptFileJob)
 
-	for i := 0; i < opts.Jobs; i++ {
+	for i := range opts.Jobs {
 		wg.Add(1)
 		go func(id int) {
 			l.Verboseln("started encryption worker", id)
@@ -1473,7 +1473,7 @@ func postProcessFiles(inFiles chan sumFileJob, wg *sync.WaitGroup, opts options)
 		}(i)
 	}
 
-	for i := 0; i < opts.Jobs; i++ {
+	for i := range opts.Jobs {
 		wg.Add(1)
 		go func(id int) {
 			l.Verboseln("started checksum worker for encrypted files", id)
@@ -1521,7 +1521,7 @@ func postProcessFiles(inFiles chan sumFileJob, wg *sync.WaitGroup, opts options)
 		repo = nil
 	}
 
-	for i := 0; i < opts.Jobs; i++ {
+	for i := range opts.Jobs {
 		wg.Add(1)
 		go func(id int) {
 			l.Verboseln("started upload worker", id)
@@ -1557,22 +1557,22 @@ func postProcessFiles(inFiles chan sumFileJob, wg *sync.WaitGroup, opts options)
 		// inFiles will be closed outside of the function, when all
 		// worker reading from it exit, close encIn to make the workers
 		// reading from it stop, and so on.
-		for i := 0; i < opts.Jobs; i++ {
+		for range opts.Jobs {
 			<-done
 		}
 		close(encIn)
 
-		for i := 0; i < opts.Jobs; i++ {
+		for range opts.Jobs {
 			<-done
 		}
 		close(sumEncIn)
 
-		for i := 0; i < opts.Jobs; i++ {
+		for range opts.Jobs {
 			<-done
 		}
 		close(uploadIn)
 
-		for i := 0; i < opts.Jobs; i++ {
+		for range opts.Jobs {
 			<-done
 		}
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -197,11 +198,8 @@ func run() (retVal error) {
 	// config file since we are using the remaining args from the command
 	// line that are usually as a list of databases to dump
 	globs := []string{}
-	for _, v := range cliOptList {
-		if v == "include-dbs" {
-			globs = opts.Dbnames
-			break
-		}
+	if slices.Contains(cliOptList, "include-dbs") {
+		globs = opts.Dbnames
 	}
 
 	// Listing remote files take priority over the other options that won't dump databases


### PR DESCRIPTION
When possible, use range instead of for loop with increment. This is a bit easier to read. This commits also removes the unnecessary id from dumper().

Also use slice.Contains() instead of looping over a slice to search an item.